### PR TITLE
Add label_class, content_class etc global option support

### DIFF
--- a/lib/show_for.rb
+++ b/lib/show_for.rb
@@ -9,11 +9,17 @@ module ShowFor
   mattr_accessor :label_tag
   @@label_tag = :strong
 
+  mattr_accessor :label_class
+  @@label_class = :label
+
   mattr_accessor :separator
   @@separator = "<br />"
 
   mattr_accessor :content_tag
   @@content_tag = nil
+
+  mattr_accessor :content_class
+  @@content_class = :content
 
   mattr_accessor :blank_content_class
   @@blank_content_class = "blank"
@@ -21,8 +27,14 @@ module ShowFor
   mattr_accessor :wrapper_tag
   @@wrapper_tag = :p
 
+  mattr_accessor :wrapper_class
+  @@wrapper_class = :wrapper
+
   mattr_accessor :collection_tag
   @@collection_tag = :ul
+
+  mattr_accessor :collection_class
+  @@collection_class = :collection
 
   mattr_accessor :default_collection_proc
   @@default_collection_proc = lambda { |value| "<li>#{ERB::Util.html_escape(value)}</li>".html_safe }

--- a/lib/show_for/builder.rb
+++ b/lib/show_for/builder.rb
@@ -46,8 +46,9 @@ module ShowFor
       tag = options.delete(:"#{type}_tag") || ShowFor.send(:"#{type}_tag")
 
       if tag
+        type_class = ShowFor.send :"#{type}_class"
         html_options = options.delete(:"#{type}_html") || {}
-        html_options[:class] = "#{type} #{html_options[:class]}".strip
+        html_options[:class] = "#{type_class} #{html_options[:class]}".strip
         @template.content_tag(tag, content, html_options)
       else
         content

--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -39,6 +39,15 @@ class BuilderTest < ActionView::TestCase
   end
 
   # WRAPPER
+  test "show_for allows wrapper to be configured globally" do
+    swap ShowFor, :wrapper_tag => "li", :wrapper_class => "my_wrapper" do
+      with_attribute_for @user, :name
+      assert_select "div.show_for li.user_name.my_wrapper"
+      assert_select "div.show_for li.my_wrapper strong.label"
+      assert_select "div.show_for li.my_wrapper"
+    end
+  end
+
   test "show_for attribute wraps each attribute with a label and content" do
     with_attribute_for @user, :name
     assert_select "div.show_for p.user_name.wrapper"
@@ -82,9 +91,9 @@ class BuilderTest < ActionView::TestCase
   end
 
   test "show_for allows label to be configured globally" do
-    swap ShowFor, :label_tag => :span do
+    swap ShowFor, :label_tag => :span, :label_class => "my_label" do
       with_attribute_for @user, :name
-      assert_select "div.show_for p.wrapper span.label"
+      assert_select "div.show_for p.wrapper span.my_label"
     end
   end
 
@@ -120,9 +129,9 @@ class BuilderTest < ActionView::TestCase
 
   # CONTENT
   test "show_for allows content tag to be configured globally" do
-    swap ShowFor, :content_tag => :span do
+    swap ShowFor, :content_tag => :span, :content_class => :my_content do
       with_attribute_for @user, :name
-      assert_select "div.show_for p.wrapper span.content"
+      assert_select "div.show_for p.wrapper span.my_content"
     end
   end
 
@@ -357,9 +366,9 @@ class BuilderTest < ActionView::TestCase
   end
 
   test "show_for allows collection tag to be configured globally" do
-    swap ShowFor, :collection_tag => :ol do
+    swap ShowFor, :collection_tag => :ol, :collection_class => "my_collection" do
       with_attribute_for @user, :scopes
-      assert_select "div.show_for p.wrapper ol.collection"
+      assert_select "div.show_for p.wrapper ol.my_collection"
     end
   end
 


### PR DESCRIPTION
Useful to customize markup even more. For example with bootstrap when .label has special meaning.
