### PR TITLE
Uses model model_name.param_key as the object name

### DIFF
--- a/lib/show_for/builder.rb
+++ b/lib/show_for/builder.rb
@@ -19,7 +19,7 @@ module ShowFor
   protected
 
     def object_name #:nodoc:
-      @object_name ||= @object.class.name.underscore
+      @object_name ||= @object.class.model_name.param_key
     end
 
     def wrap_label_and_content(name, value, options, &block) #:nodoc:
@@ -38,13 +38,13 @@ module ShowFor
       wrapper_html = options[:wrapper_html] ||= {}
       wrapper_html[:class] = "#{html_class} #{wrapper_html[:class]}".rstrip
     end
-    
+
     def apply_wrapper_options!(type, options, value)
       options[:"#{type}_html"] ||= {}
       options[:"#{type}_html"][:class] = [options[:"#{type}_html"][:class], ShowFor.blank_content_class].join(' ') if value.blank? && value != false
       options
     end
-    
+
     # Gets the default tag set in ShowFor module and apply (if defined)
     # around the given content. It also check for html_options in @options
     # hash related to the current type.

--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -18,6 +18,15 @@ class BuilderTest < ActionView::TestCase
     assert_select "div.show_for p.wrapper"
   end
 
+  test "show_for properly deals with namespaced models" do
+    @user = Namespaced::User.new(:id => 1, :name => "ShowFor")
+
+    with_attribute_for @user, :name
+    assert_select "div.show_for p.namespaced_user_name.wrapper"
+    assert_select "div.show_for p.wrapper strong.label"
+    assert_select "div.show_for p.wrapper"
+  end
+
   test "show_for allows wrapper tag to be changed by attribute" do
     with_attribute_for @user, :name, :wrapper_tag => :span
     assert_select "div.show_for span.user_name.wrapper"

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -49,3 +49,8 @@ class User < OpenStruct
     "User"
   end
 end
+
+module Namespaced
+  class User < ::User
+  end
+end


### PR DESCRIPTION
For a namespaced model like Blog::Post, show_for outputs the model name as blogpost (so an attribute is output with a class blogpost_body). On Rails forms, it is output as blog_post (blog_post_body). To have that same behavior, this pull request changes show_for to get the object name from the model model_name.param_key.

Tests pass with this change, but I'm not sure if we should add a test about namespacing. Please let me know what you think :)
