### PR TITLE
Fix belongs_to associations with block

### DIFF
--- a/lib/show_for/association.rb
+++ b/lib/show_for/association.rb
@@ -16,7 +16,9 @@ module ShowFor
       # since we want the collection to be yielded. Otherwise, calculate the values.
       value = if collection_block?(block)
         collection_block = block
-        @object.send(association_name)
+        associations = @object.send(association_name)
+        options[:collection_tag] = '' unless associations.kind_of? Array
+        Array.wrap associations
       elsif block
         block
       else

--- a/lib/show_for/builder.rb
+++ b/lib/show_for/builder.rb
@@ -60,13 +60,13 @@ module ShowFor
     def wrap_with(type, content, options) #:nodoc:
       tag = options.delete(:"#{type}_tag") || ShowFor.send(:"#{type}_tag")
 
-      if tag
+      if tag.blank?
+        content
+      else
         type_class = ShowFor.send :"#{type}_class"
         html_options = options.delete(:"#{type}_html") || {}
         html_options[:class] = "#{type_class} #{html_options[:class]}".rstrip
         @template.content_tag(tag, content, html_options)
-      else
-        content
       end
     end
 


### PR DESCRIPTION
There is attempt to fix issue #50.

The only difference between `has_many` and `belongs_to` for show_for is that `has_many` returns array, and `belongs_to` returns single object, that is not wrapped inside array. So simple `Array.wrap` fixes the issue. Only one line of code. But wrapping `belongs_to` 'collection' inside `collection_tag` is not needed, it is better to display it inline with its label, so some additional code is needed.

It maybe looks like a hack, because `options[:collection_tag]` is set to empty string, and `wrap_with` was modified to handle empty tags correctly. I'm not sure is it better to use some instance variable instead.
