### PR TITLE
Fix the show_tag_class option, that wasnt been added to the tag classes.

### DIFF
--- a/lib/show_for/helper.rb
+++ b/lib/show_for/helper.rb
@@ -15,7 +15,9 @@ module ShowFor
       tag = html_options.delete(:show_for_tag) || ShowFor.show_for_tag
 
       html_options[:id]  ||= dom_id(object)
-      html_options[:class] = show_for_html_class(object, html_options)
+      klass = (html_options.delete(:show_for_class) || "")
+      klass += show_for_html_class(object, html_options)
+      html_options[:class] = klass
 
       builder = html_options.delete(:builder) || ShowFor::Builder
       content = capture(builder.new(object, self), &block)


### PR DESCRIPTION
show_for was ignoring options like:

``` ruby
config.show_for_class = 'dl-horizontal'
```

This PR should fix that.

Anyway, my code doesn't look good enough... I'm accepting suggestions.

Thanks.
