### PR TITLE
`capture` expects a string, so non-string content gets ignored. 

### DIFF
--- a/lib/show_for/attribute.rb
+++ b/lib/show_for/attribute.rb
@@ -44,7 +44,7 @@ module ShowFor
       when Symbol
         block_from_symbol(attribute_name, options)
       else
-        lambda { options[:value] }
+        lambda { options[:value].to_s }
       end
     end
 

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -158,6 +158,11 @@ class AttributeTest < ActionView::TestCase
     assert_select "div.show_for p.wrapper", /Calculated Value/
   end
 
+  test "show_for uses :value and casts to string if supplied" do
+    with_attribute_for @user, :name, :value => 123
+    assert_select "div.show_for p.wrapper", /123/
+  end
+
   test "show_for ignores :value if a block is supplied" do
     with_attribute_for @user, :name, :value => "Calculated Value" do
       @user.name.upcase


### PR DESCRIPTION
`capture` expects a string, so non-string content gets ignored. This fixes that by casting the custom value to a string.
