### PR TITLE
Do not pass blank_value to block.

### DIFF
--- a/lib/show_for/content.rb
+++ b/lib/show_for/content.rb
@@ -5,10 +5,6 @@ module ShowFor
       # cache value for apply_wrapper_options!
       sample_value = value
 
-      if value.blank? && value != false
-        value = blank_value(options)
-      end
-
       # We need to convert value to_a because when dealing with ActiveRecord
       # Array proxies, the follow statement Array# === value return false
       value = value.to_a if value.is_a?(Array)
@@ -27,7 +23,9 @@ module ShowFor
         when NilClass, Numeric
           value.to_s
         else
-          if block
+          if value.blank?
+            blank_value(options)
+          elsif block
             template.capture(value, &block)
           else
             value
@@ -41,6 +39,8 @@ module ShowFor
   protected
 
     def collection_handler(value, options, &block) #:nodoc:
+      return blank_value(options) if value.blank?
+
       iterator = collection_block?(block) ? block : ShowFor.default_collection_proc
 
       response = value.map do |item|

--- a/test/association_test.rb
+++ b/test/association_test.rb
@@ -42,6 +42,20 @@ class AssociationTest < ActionView::TestCase
     end
   end
 
+  test "show_for accepts a block with has_many/has_and_belongs_to_many blank associations" do
+    def @user.tags
+      []
+    end
+
+    swap ShowFor, :association_methods => [:name] do
+      with_association_for @user, :tags do |tag|
+        tag.name
+      end
+      assert_no_select "div.show_for p.wrapper ul.collection"
+      assert_no_select "div.show_for p.wrapper", /Enumerator/
+    end
+  end
+
   test "show_for accepts a block with an argument in belongs_to associations" do
     with_association_for @user, :company do |company|
       company.name.upcase


### PR DESCRIPTION
This fixes the problem wherein "Not specified." is passed
to the association block when the association is empty.
