### PR TITLE
Moves blank check to after content transformation to catch blank proc and block values

### DIFF
--- a/lib/show_for/content.rb
+++ b/lib/show_for/content.rb
@@ -5,10 +5,6 @@ module ShowFor
       # cache value for apply_wrapper_options!
       sample_value = value
 
-      if value.blank? && value != false
-        value = blank_value(options)
-      end
-
       # We need to convert value to_a because when dealing with ActiveRecord
       # Array proxies, the follow statement Array# === value return false
       value = value.to_a if value.is_a?(Array)
@@ -32,6 +28,10 @@ module ShowFor
           else
             value
           end
+      end
+
+      if content.blank?
+        content = blank_value(options)
       end
 
       options[:content_html] = options.except(:content_tag) if apply_options

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -133,6 +133,13 @@ class AttributeTest < ActionView::TestCase
     assert_select "div.show_for p.wrapper", /This description/
   end
 
+  test "show_for uses :if_blank if the block content is blank" do
+    with_attribute_for @user, :description, :if_blank => "No description provided" do
+      ""
+    end
+    assert_select "div.show_for p.wrapper", /No description provided/
+  end
+
   test "show_for#content given a block should be wrapped in the result" do
     with_attribute_for @user, :name do |name|
       "<div class='block'>#{name}</div>".html_safe


### PR DESCRIPTION
Currently if you have a display like so:

``` erb
<%= show_for :normal_attr, if_blank: "Not here" %>
<%= show_for :custom_thingy, if_blank: "Also not here" do %>
  <%= print_out_some_fancy_stuff_sometimes_blank %>
<% end %>
```

The page will display "Normal attr: Not here" but "Custom thingy: " 

This fixes that so blocks and procs also respect the if_blank option.  

Note that the use of `blank?` means any non-whitespace chars, including html will prevent the message from displaying, but this very simple change seems like a huge improvement and it fixes our use case.
