### PR TITLE
Use duck type instead of class check

### DIFF
--- a/lib/show_for/association.rb
+++ b/lib/show_for/association.rb
@@ -38,7 +38,7 @@ module ShowFor
   protected
 
     def values_from_association(association, options) #:nodoc:
-      sample = association.is_a?(Array) ? association.first : association
+      sample = association.respond_to?(:first) ? association.first : association
 
       if options[:method]
         options[:using] = options.delete(:method)
@@ -48,7 +48,7 @@ module ShowFor
       method = options.delete(:using) || ShowFor.association_methods.find { |m| sample.respond_to?(m) }
 
       if method
-        association.is_a?(Array) ? association.map(&method) : association.try(method)
+        association.respond_to?(:map) ? association.map(&method) : association.try(method)
       end
     end
   end

--- a/lib/show_for/content.rb
+++ b/lib/show_for/content.rb
@@ -11,7 +11,7 @@ module ShowFor
 
       # We need to convert value to_a because when dealing with ActiveRecord
       # Array proxies, the follow statement Array# === value return false
-      value = value.to_a if value.is_a?(Array)
+      value = value.to_a if value.is_a?(Array) || value.respond_to?(:load_target)
 
       content = case value
         when Date, Time, DateTime

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -1,15 +1,43 @@
 require 'ostruct'
 
-class Company < Struct.new(:id, :name)
+class Company
   extend ActiveModel::Naming
+
+  attr_accessor :id, :name
+
+  def initialize(id, name)
+    @id = id
+    @name = name
+  end
 
   def alternate_name
     "Alternate #{self.name}"
   end
 end
 
-class Tag < Struct.new(:id, :name)
+class FakeCollectionProxy
+  include Enumerable
+
+  def initialize(collection)
+    @collection = collection
+  end
+
+  def each(&block)
+    @collection.each(&block)
+  end
+
+  alias :load_target :to_a
+end
+
+class Tag
   extend ActiveModel::Naming
+
+  attr_accessor :id, :name
+
+  def initialize(id, name)
+    @id = id
+    @name = name
+  end
 
   def self.all(options={})
     (1..3).map{ |i| Tag.new(i, "Tag #{i}") }
@@ -27,7 +55,7 @@ class User < OpenStruct
   undef_method :id if respond_to?(:id)
 
   def tags
-    Tag.all
+    FakeCollectionProxy.new(Tag.all)
   end
 
   def company


### PR DESCRIPTION
Rails 4 returns a CollectionProxy object when you call the association
method, so we need to check if the object we have respond to some
methods instead of checking if it is an Array

Fixes #61
