### PR TITLE
Ignore attribute when value option has been specified but provided with nil value

### DIFF
--- a/lib/show_for/attribute.rb
+++ b/lib/show_for/attribute.rb
@@ -38,10 +38,10 @@ module ShowFor
     end
 
     def block_from_value_option(attribute_name, options)
-      case options[:value]
-      when nil
-        options.has_key?(:value) ? '' : nil
-      when Symbol
+      case
+      when !options.has_key?(:value)
+        nil
+      when options[:value].is_a?(Symbol)
         block_from_symbol(attribute_name, options)
       else
         lambda { options[:value].to_s }

--- a/lib/show_for/attribute.rb
+++ b/lib/show_for/attribute.rb
@@ -40,7 +40,7 @@ module ShowFor
     def block_from_value_option(attribute_name, options)
       case options[:value]
       when nil
-        nil
+        options.has_key?(:value) ? '' : nil
       when Symbol
         block_from_symbol(attribute_name, options)
       else

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -187,6 +187,11 @@ class AttributeTest < ActionView::TestCase
     assert_select "div.show_for div.wrapper", /123/
   end
 
+  test "show_for ignores attribute if :value supplied but with nil value" do
+    with_attribute_for @user, :name, :value => nil
+    assert_select "div.show_for div.wrapper", /Not specified/
+  end
+
   test "show_for ignores :value if a block is supplied" do
     with_attribute_for @user, :name, :value => "Calculated Value" do
       @user.name.upcase


### PR DESCRIPTION
In some cases, we need to use show specifeid values on page, and the value might not existed on model actually. We will use `:value` option to speified the value. Such as:

```
<%= f.attribute :card_no, value: obj.card_no %>
```

Sometimes, the `:value` option specified might get nil value, if so, show_for will still continue to get attribute from model object. But we might use a not existed attribute from model. I think the reason we are using `:value` option is because we don't want to show attribute from object directly. If `:value` option has been specified, even it came nil value, I think we still need to avoid getting value from attribute of that model object. 

This commit was trying to change the original behavior. As described above, when `:value` option has been specified, but with nil value provided, show_fow won't try to retrieve attribute value from model object.
